### PR TITLE
Update data directory permission

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -14,7 +14,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --device=dri
-  - --persist=.kingsoft
+  - --filesystem=~/.local/share/Kingsoft:create
   - --env=TMPDIR=/var/tmp
   - --filesystem=xdg-documents
   - --filesystem=xdg-download


### PR DESCRIPTION
WPS has changed data directory location from `~/.kingsoft` to `~/.local/share/Kingsoft`. Sadly, the later is hardcoded, so we need to mount it inside the sandbox. If we just make it persistent, the "open backups folder" button wouldn't work.
Fixes #34 