### PR TITLE
Update to 11.1.0.8722

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -6,13 +6,13 @@ mkdir -p deb-package export/share
 ar p wps-office.deb data.tar.xz | tar -xJf - -C deb-package
 
 mv deb-package/opt/kingsoft/wps-office .
-mv deb-package/usr/bin/{wps,wpp,et} wps-office/
+mv deb-package/usr/bin/{wps,wpp,et,wpspdf} wps-office/
 mv deb-package/usr/share/{icons,applications,mime} export/share/
 rm export/share/applications/appurl.desktop
 
 rename "wps-office-" "com.wps.Office." export/share/{icons/hicolor/*/*,applications,mime/packages}/wps-office-*.*
 
-for a in wps wpp et; do
+for a in wps wpp et pdf; do
     desktop_file="export/share/applications/com.wps.Office.$a.desktop"
     desktop-file-edit --set-key="Exec" --set-value="$a %f" "$desktop_file"
     desktop-file-edit --set-key="Icon" --set-value="com.wps.Office.${a}main" "$desktop_file"

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+shopt -s failglob
 
 mkdir -p deb-package export/share
 
@@ -10,12 +11,19 @@ mv deb-package/usr/bin/{wps,wpp,et,wpspdf} wps-office/
 mv deb-package/usr/share/{icons,applications,mime} export/share/
 rm export/share/applications/appurl.desktop
 
+YEAR_SUFFIX=2019
+
 rename "wps-office-" "com.wps.Office." export/share/{icons/hicolor/*/*,applications,mime/packages}/wps-office-*.*
+rename "wps-office${YEAR_SUFFIX}" "com.wps.Office.${YEAR_SUFFIX}" export/share/icons/hicolor/*/*/wps-office${YEAR_SUFFIX}-*.*
 
 for a in wps wpp et pdf; do
     desktop_file="export/share/applications/com.wps.Office.$a.desktop"
-    desktop-file-edit --set-key="Exec" --set-value="$a %f" "$desktop_file"
-    desktop-file-edit --set-key="Icon" --set-value="com.wps.Office.${a}main" "$desktop_file"
+    case "$a" in
+        pdf) appbin=wpspdf ;;
+        *) appbin="$a" ;;
+    esac
+    desktop-file-edit --set-key="Exec" --set-value="$appbin %f" "$desktop_file"
+    desktop-file-edit --set-key="Icon" --set-value="com.wps.Office.${YEAR_SUFFIX}-${a}main" "$desktop_file"
     desktop-file-edit --set-key="X-Flatpak-RenamedFrom" --set-value="wps-office-$a.desktop;" "$desktop_file"
 done
 sed -i 's/generic-icon name="wps-office-/icon name="com.wps.Office./g' export/share/mime/packages/com.wps.Office.*.xml

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -12,34 +12,11 @@ rm export/share/applications/appurl.desktop
 
 rename "wps-office-" "com.wps.Office." export/share/{icons/hicolor/*/*,applications,mime/packages}/wps-office-*.*
 
-ooxml_mime="application/vnd.openxmlformats-officedocument"
-extra_mime_types_wps=(
-    "${ooxml_mime}.wordprocessingml.document"
-    "${ooxml_mime}.wordprocessingml.template"
-)
-extra_mime_types_wpp=(
-    "${ooxml_mime}.presentationml.presentation"
-    "${ooxml_mime}.presentationml.slideshow"
-    "${ooxml_mime}.presentationml.template"
-)
-extra_mime_types_et=(
-    "${ooxml_mime}.spreadsheetml.sheet"
-    "${ooxml_mime}.spreadsheetml.template"
-)
-declare -A extra_mime_types=(
-    [wps]=${extra_mime_types_wps[@]}
-    [wpp]=${extra_mime_types_wpp[@]}
-    [et]=${extra_mime_types_et[@]}
-)
-
 for a in wps wpp et; do
     desktop_file="export/share/applications/com.wps.Office.$a.desktop"
     desktop-file-edit --set-key="Exec" --set-value="$a %f" "$desktop_file"
     desktop-file-edit --set-key="Icon" --set-value="com.wps.Office.${a}main" "$desktop_file"
     desktop-file-edit --set-key="X-Flatpak-RenamedFrom" --set-value="wps-office-$a.desktop;" "$desktop_file"
-    for extra_mime_type in ${extra_mime_types[$a]}; do
-        desktop-file-edit --add-mime-type="${extra_mime_type}" "$desktop_file"
-    done
 done
 sed -i 's/generic-icon name="wps-office-/icon name="com.wps.Office./g' export/share/mime/packages/com.wps.Office.*.xml
 

--- a/com.wps.Office.appdata.xml
+++ b/com.wps.Office.appdata.xml
@@ -28,6 +28,7 @@
     <category>Office</category>
   </categories>
   <releases>
+    <release version="11.1.0.8722" date="2019-07-05"/>
     <release version="11.1.0.8392" date="2019-04-15"/>
     <release version="11.1.0.8372" date="2019-04-02"/>
     <release version="10.1.0.6758" date="2019-03-09"/>
@@ -160,33 +161,5 @@
     <category>Office</category>
     <category>Presentation</category>
   </categories>
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
+  <content_rating type="oars-1.1"/>
 </component>

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -85,14 +85,6 @@ modules:
         filename: wps-office.deb
         only-arches:
           - 'x86_64'
-        url: "http://kdl.cc.ksosoft.com/wps-community/download/8392/wps-office_11.1.0.8392_amd64.deb"
-        sha256: ef7569493819cfc44e1623cfc87010d5ef565ac43c16a4cd1095c05b50b77c2f
-        size: 213113086
-
-      - type: extra-data
-        filename: wps-office.deb
-        only-arches:
-          - 'i386'
-        url: "http://kdl.cc.ksosoft.com/wps-community/download/8392/wps-office_11.1.0.8392_i386.deb"
-        sha256: 54494cbfd48a5c468573f5630582747a318408480bf44a55ddc2d261fa27d5f4
-        size: 216166080
+        url: "http://kdl.cc.ksosoft.com/wps-community/download/8722/wps-office_11.1.0.8722_amd64.deb"
+        sha256: 9b314922fb164465f362b0000f46fcd48f5d6cf9ae5b5331c9865914eb50290b
+        size: 259160398

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -65,6 +65,7 @@ modules:
       - install -Dm755 wps.sh /app/bin/wps
       - ln -s wps /app/bin/et
       - ln -s wps /app/bin/wpp
+      - ln -s wps /app/bin/wpspdf
       - install -Dm644 ${FLATPAK_ID}.appdata.xml -t /app/share/appdata/
       - install -Dm755 /usr/bin/desktop-file-edit -t /app/bin/
       - install -Dm755 /usr/bin/ar -t /app/bin/

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
   "publish-delay-hours": 0,
-  "only-arches": ["i386", "x86_64"]
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Fixes #37

Icons got messed up again: 
- now apps icons are in `mimetypes` subdirectory, not sure how all DEs would handle it
- apps icons are now suffixed with year, third-party icon themes would need to be updated

OOXML mimetypes in desktop files seems fixed now.