### PR TITLE
Temporarily switch to Deepin mirror

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -86,6 +86,6 @@ modules:
         filename: wps-office.deb
         only-arches:
           - 'x86_64'
-        url: "http://kdl.cc.ksosoft.com/wps-community/download/8722/wps-office_11.1.0.8722_amd64.deb"
+        url: "http://packages.deepin.com/deepin/pool/non-free/w/wps-office/wps-office_11.1.0.8722_amd64.deb"
         sha256: 9b314922fb164465f362b0000f46fcd48f5d6cf9ae5b5331c9865914eb50290b
         size: 259160398


### PR DESCRIPTION
Updating checksums to match the the actual package seems just wrong. Using the package from other location that matches current checksum seems better. Fixes #40