### PR TITLE
Drop qt4 module and build on KDE SDK

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -1,7 +1,7 @@
 id: com.wps.Office
 runtime: org.freedesktop.Platform
-runtime-version: '18.08'
-sdk: org.freedesktop.Sdk
+runtime-version: '19.08'
+sdk: org.kde.Sdk//5.13
 tags:
   - proprietary
 command: wps
@@ -33,18 +33,12 @@ cleanup:
   - /include
   - /lib/pkgconfig
   - /lib/cmake
-  # Remove Qt, it's bubdled
-  - /lib/libQt*
-  - /lib/qt4
-  - /share/qt4
 modules:
   - shared-modules/gtk2/gtk2.json
 
-  - shared-modules/qt4/qt4-4.8.7-minimal.json
-
   - shared-modules/udev/udev-175.json
 
-  - shared-modules/glu/glu-9.0.0.json
+  - shared-modules/glu/glu-9.json
 
   - name: wps-i18n
     no-autogen: true

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -86,9 +86,9 @@ modules:
         only-arches:
           - 'x86_64'
         url: "http://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/8865/wps-office_11.1.0.8865_amd64.deb"
-        sha256: 4ae360aeaadb7c0e73b879bc940c8351901a245998e33fa0f5f25940d5b42d27
-        size: 252991358
-        installed-size: 988628479
+        sha256: a8adc62d0c5245ed312d6454437c924b7760dacd5f7a71aeb5997ee85590d7c1
+        size: 252362146
+        installed-size: 988671247
         x-checker-data:
           type: html
           url: "https://linux.wps.com/js/meta.js"


### PR DESCRIPTION
It seems like we can use `lrelease` from Qt5 to build translations. If we can drop Qt4 module, we can also update runtime to 19.08, and fix #48