### PR TITLE
Drop udev submodule

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -36,8 +36,6 @@ cleanup:
 modules:
   - shared-modules/gtk2/gtk2.json
 
-  - shared-modules/udev/udev-175.json
-
   - shared-modules/glu/glu-9.json
 
   - name: wps-i18n


### PR DESCRIPTION
Since fdo 19.08/kde 5.13 libudev is in Platform.