### PR TITLE
allow session bus access to org.fcitx.Fcitx-99

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -20,6 +20,8 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=/run/media
   - --filesystem=/media
+# required for fcitx5's fcitx4frontend addon
+  - --talk-name=org.fcitx.*
 add-extensions:
   com.wps.Office.spellcheck:
     directory: extra/wps-office/office6/dicts/spellcheck


### PR DESCRIPTION
This allows making use of Fcitx5 with only setting the `QT_IM_MODULE` environment variable to `fcitx`
as it's more backward-compatible than setting it to `fcitx5`.

This requires the fcitx4frontend addon of Fcitx5 that was added by https://github.com/fcitx/fcitx5/commit/7780c8f7f9bcde2fcff6ae7fc3ce5ab2c40ebe63
so it will only work with Fcitx5 5.0.4 or newer releases.

Closes #80

Currently only works with the Flatpak Fcitx5 package.  
Distro/host Fcitx package won't work with this due to a mismatch between the DISPLAY variable environment value in the sandbox and the value in the host environment which means the Flatpak WPS app tries to access `org.fcitx.Fcitx-99` on the session bus that does not exist, see https://github.com/fcitx/fcitx5/issues/204