### PR TITLE
Replace wps bundled one im module with Fcitx offical version.

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -38,3 +38,8 @@ done
 sed -i "s/generic-icon name=\"wps-office-/icon name=\"${FLATPAK_ID}./g" "export/share/mime/packages/${FLATPAK_ID}".*.xml
 
 rm -r wps-office.deb deb-package
+
+# Remove the WPS own im module and replace with the fcitx offical one.
+rm wps-office/office6/qt/plugins/inputmethods/libqim-fcitx.so
+# While ln -s works, qt factory cache does not work properly on refreshing on symlink.
+cp /app/lib/qtim-fcitx.so wps-office/office6/qt/plugins/inputmethods/

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -39,7 +39,5 @@ sed -i "s/generic-icon name=\"wps-office-/icon name=\"${FLATPAK_ID}./g" "export/
 
 rm -r wps-office.deb deb-package
 
-# Remove the WPS own im module and replace with the fcitx offical one.
-rm wps-office/office6/qt/plugins/inputmethods/libqim-fcitx.so
-# While ln -s works, qt factory cache does not work properly on refreshing on symlink.
-cp /app/lib/qtim-fcitx.so wps-office/office6/qt/plugins/inputmethods/
+# Remove plugin path so we can override the default path with based on QT_PLUGIN_PATH
+sed -i 's|^Plugins=.*||g' wps-office/office6/qt.conf

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -20,6 +20,7 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=/run/media
   - --filesystem=/media
+  - --env=QT_PLUGIN_PATH=/app/lib/qt:/app/extra/wps-office/office6/qt/plugins
 add-extensions:
   com.wps.Office.spellcheck:
     directory: extra/wps-office/office6/dicts/spellcheck

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -20,8 +20,6 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=/run/media
   - --filesystem=/media
-# required for fcitx5's fcitx4frontend addon
-  - --talk-name=org.fcitx.*
 add-extensions:
   com.wps.Office.spellcheck:
     directory: extra/wps-office/office6/dicts/spellcheck
@@ -39,6 +37,8 @@ modules:
   - shared-modules/gtk2/gtk2.json
 
   - shared-modules/glu/glu-9.json
+
+  - modules/fcitx-im-module.yml
 
   - name: wps
     buildsystem: simple
@@ -75,3 +75,4 @@ modules:
           url: https://linux.wps.com/js/meta.js
           version-pattern: version\s*=\s*"([\d.-]+)"
           url-pattern: download_link_deb\s*=\s*"(http[s]?://[\w\d$-_@.&+]+)"
+

--- a/modules/build_fcitx5.sh
+++ b/modules/build_fcitx5.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+mkdir -p deb-package
+ar p wps-office.deb data.tar.xz | tar -xJf - -C deb-package
+
+WPS_LIBRARY_DIR=$PWD/deb-package/opt/kingsoft/wps-office/office6
+
+sed -i 's/^CFG_INOTIFY=.*/CFG_INOTIFY=no/g' configure
+./configure -opensource -confirm-license -prefix $PWD
+# Build only the necessary part
+make -C src/tools/bootstrap
+make -C src/tools/moc
+make -C src/tools/uic
+make -C src/tools/rcc
+make -C src/corelib
+
+# Replace the mismatch qconfig with wps ones.
+chmod +w src/corelib/global/qconfig.h
+sed -i 's|\(#define QT_BUILD_KEY.*\) ".*"|\1 "x86_64 Linux clang full-config"|g' src/corelib/global/qconfig.h
+
+cd fcitx5-wps
+mkdir build
+cd build
+cmake -DQT_QMAKE_EXECUTABLE=$PWD/../../bin/qmake -DWPS_LIBRARY_DIR=$WPS_LIBRARY_DIR ..
+make install
+
+cp $WPS_LIBRARY_DIR/qt/plugins/inputmethods/qtim-fcitx.so /app/lib
+
+

--- a/modules/build_fcitx5.sh
+++ b/modules/build_fcitx5.sh
@@ -21,6 +21,7 @@ cd build
 cmake -DQT_QMAKE_EXECUTABLE=$PWD/../../bin/qmake -DWPS_LIBRARY_DIR=$WPS_LIBRARY_DIR ..
 make install
 
-cp $WPS_LIBRARY_DIR/qt/plugins/inputmethods/qtim-fcitx.so /app/lib
+mkdir -p /app/lib/qt
+mv $WPS_LIBRARY_DIR/qt/plugins/inputmethods/ /app/lib/qt
 
 

--- a/modules/build_fcitx5.sh
+++ b/modules/build_fcitx5.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-WPS_LIBRARY_DIR=$PWD/deb-package/opt/kingsoft/wps-office/office6
+WPS_LIBRARY_DIR=$PWD/wps
 
 sed -i 's/^CFG_INOTIFY=.*/CFG_INOTIFY=no/g' configure
 ./configure -opensource -confirm-license -prefix $PWD
 # Build only the necessary part
-make -C src/tools/bootstrap
-make -C src/tools/moc
-make -C src/tools/uic
-make -C src/tools/rcc
-make -C src/corelib
+make -C src/tools/bootstrap -j$FLATPAK_BUILDER_N_JOBS
+make -C src/tools/moc -j$FLATPAK_BUILDER_N_JOBS
+make -C src/tools/uic -j$FLATPAK_BUILDER_N_JOBS
+make -C src/tools/rcc -j$FLATPAK_BUILDER_N_JOBS
+make -C src/corelib -j$FLATPAK_BUILDER_N_JOBS
 
 # Replace the mismatch qconfig with wps ones.
 chmod +w src/corelib/global/qconfig.h
@@ -19,6 +19,7 @@ cd fcitx5-wps
 mkdir build
 cd build
 cmake -DQT_QMAKE_EXECUTABLE=$PWD/../../bin/qmake -DWPS_LIBRARY_DIR=$WPS_LIBRARY_DIR ..
+make -j$FLATPAK_BUILDER_N_JOBS
 make install
 
 mkdir -p /app/lib/qt

--- a/modules/build_fcitx5.sh
+++ b/modules/build_fcitx5.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-mkdir -p deb-package
-ar p wps-office.deb data.tar.xz | tar -xJf - -C deb-package
-
 WPS_LIBRARY_DIR=$PWD/deb-package/opt/kingsoft/wps-office/office6
 
 sed -i 's/^CFG_INOTIFY=.*/CFG_INOTIFY=no/g' configure

--- a/modules/fcitx-im-module.yml
+++ b/modules/fcitx-im-module.yml
@@ -7,12 +7,9 @@ sources:
   - type: git
     url: https://github.com/wengxt/fcitx5-wps
     dest: fcitx5-wps
+    commit: b40a3df29d1243824c46b2e1abb833cfcb5b14c3
   - type: file
     path: build_fcitx5.sh
-  - type: file
-    url: https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/10161/wps-office_11.1.0.10161.XA_amd64.deb
-    sha256: 8ca6084428693c81833f6fdf13442a9ea9052638d5bdc0e4d7512075f40007c3
-    dest-filename: wps-office.deb
 build-commands:
   - ./build_fcitx5.sh
 modules:

--- a/modules/fcitx-im-module.yml
+++ b/modules/fcitx-im-module.yml
@@ -7,7 +7,7 @@ sources:
   - type: git
     url: https://github.com/wengxt/fcitx5-wps
     dest: fcitx5-wps
-    commit: b40a3df29d1243824c46b2e1abb833cfcb5b14c3
+    commit: f5c46de67b85c00457c30c96feafc60cbd6fa874
   - type: file
     path: build_fcitx5.sh
 build-commands:

--- a/modules/fcitx-im-module.yml
+++ b/modules/fcitx-im-module.yml
@@ -1,0 +1,28 @@
+name: fcitx-im-module
+buildsystem: simple
+sources:
+  - type: archive
+    url: https://download.qt.io/archive/qt/4.7/qt-everywhere-opensource-src-4.7.4.tar.gz
+    sha256: 97195ebce8a46f9929fb971d9ae58326d011c4d54425389e6e936514f540221e
+  - type: git
+    url: https://github.com/wengxt/fcitx5-wps
+    dest: fcitx5-wps
+  - type: file
+    path: build_fcitx5.sh
+  - type: file
+    url: https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/10161/wps-office_11.1.0.10161.XA_amd64.deb
+    sha256: 8ca6084428693c81833f6fdf13442a9ea9052638d5bdc0e4d7512075f40007c3
+    dest-filename: wps-office.deb
+build-commands:
+  - ./build_fcitx5.sh
+modules:
+  - name: extra-cmake-modules
+    cleanup:
+      - "*"
+    buildsystem: cmake-ninja
+    config-opts:
+      - "-DENABLE_TESTING=OFF"
+    sources:
+      - type: git
+        url: https://invent.kde.org/frameworks/extra-cmake-modules.git
+        branch: "v5.78.0"

--- a/wps.sh
+++ b/wps.sh
@@ -34,4 +34,5 @@ else
     msg "Data dir exists, not touching it"
 fi
 
-exec "/app/extra/wps-office/$(basename "$0")" "$@"
+# Override plugin path
+QT_PLUGIN_PATH=/app/lib/qt:/app/extra/wps-office/office6/qt/plugins exec "/app/extra/wps-office/$(basename "$0")" "$@"

--- a/wps.sh
+++ b/wps.sh
@@ -34,5 +34,4 @@ else
     msg "Data dir exists, not touching it"
 fi
 
-# Override plugin path
-QT_PLUGIN_PATH=/app/lib/qt:/app/extra/wps-office/office6/qt/plugins exec "/app/extra/wps-office/$(basename "$0")" "$@"
+exec "/app/extra/wps-office/$(basename "$0")" "$@"


### PR DESCRIPTION
While Fcitx does have offical support for flatpak, the problem is wps is not using fcitx offical code nor update to offical version, originally because of license issue. As Fcitx upstream we re-licensed the relevant code to BSD for upstream inclusion and informed WPS upstream about this, but they didn't take any action yet. Hopefully this won't be required in the future.

This fcitx5 im module supports both fcitx (from 4.2.9.7 due to upstream flatpak change) and fcitx5.