### PR TITLE
Switch Qt4 to git source

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -20,7 +20,7 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=/run/media
   - --filesystem=/media
-  - --env=QT_PLUGIN_PATH=/app/lib/qt:/app/extra/wps-office/office6/qt/plugins
+  - --env=QT_PLUGIN_PATH=/app/lib/qt/plugins:/app/extra/wps-office/office6/qt/plugins
 add-extensions:
   com.wps.Office.spellcheck:
     directory: extra/wps-office/office6/dicts/spellcheck

--- a/modules/build_fcitx5.sh
+++ b/modules/build_fcitx5.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+set -e
 
-WPS_LIBRARY_DIR=$PWD/wps
-
+pushd qt
 sed -i 's/^CFG_INOTIFY=.*/CFG_INOTIFY=no/g' configure
-./configure -opensource -confirm-license -prefix $PWD
+./configure \
+    -opensource \
+    -confirm-license \
+    -prefix $PWD
 # Build only the necessary part
 make -C src/tools/bootstrap -j$FLATPAK_BUILDER_N_JOBS
 make -C src/tools/moc -j$FLATPAK_BUILDER_N_JOBS
@@ -14,15 +17,13 @@ make -C src/corelib -j$FLATPAK_BUILDER_N_JOBS
 # Replace the mismatch qconfig with wps ones.
 chmod +w src/corelib/global/qconfig.h
 sed -i 's|\(#define QT_BUILD_KEY.*\) ".*"|\1 "x86_64 Linux clang full-config"|g' src/corelib/global/qconfig.h
+popd
 
-cd fcitx5-wps
-mkdir build
-cd build
-cmake -DQT_QMAKE_EXECUTABLE=$PWD/../../bin/qmake -DWPS_LIBRARY_DIR=$WPS_LIBRARY_DIR ..
-make -j$FLATPAK_BUILDER_N_JOBS
-make install
-
-mkdir -p /app/lib/qt
-mv $WPS_LIBRARY_DIR/qt/plugins/inputmethods/ /app/lib/qt
-
-
+pushd fcitx5-wps
+cmake \
+    -DQT_QMAKE_EXECUTABLE=$PWD/../qt/bin/qmake \
+    -DWPS_LIBRARY_DIR=$FLATPAK_DEST/lib \
+    -S . -B build
+make -C build -j$FLATPAK_BUILDER_N_JOBS
+make -C build install
+popd

--- a/modules/fcitx-im-module.yml
+++ b/modules/fcitx-im-module.yml
@@ -3,6 +3,7 @@ buildsystem: simple
 sources:
   - type: git
     url: https://github.com/qt/qt.git
+    dest: qt
     tag: v4.7.4
     commit: 092cd760d5fddf9640a310214fe01929f0fff3a8
   - type: git

--- a/modules/fcitx-im-module.yml
+++ b/modules/fcitx-im-module.yml
@@ -1,9 +1,10 @@
 name: fcitx-im-module
 buildsystem: simple
 sources:
-  - type: archive
-    url: https://download.qt.io/archive/qt/4.7/qt-everywhere-opensource-src-4.7.4.tar.gz
-    sha256: 97195ebce8a46f9929fb971d9ae58326d011c4d54425389e6e936514f540221e
+  - type: git
+    url: https://github.com/qt/qt.git
+    tag: v4.7.4
+    commit: 092cd760d5fddf9640a310214fe01929f0fff3a8
   - type: git
     url: https://github.com/wengxt/fcitx5-wps
     dest: fcitx5-wps


### PR DESCRIPTION
Looks like Qt4 source tarballs are gone, so we have to use git now.