### PR TITLE
Fix issues with 23.08 runtime.

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -41,6 +41,9 @@ for a in wps wpp et pdf prometheus; do
 done
 sed -i "s/generic-icon name=\"wps-office-/icon name=\"${FLATPAK_ID}./g" "export/share/mime/packages/${FLATPAK_ID}".*.xml
 
+# Just use libstdc++.so.6 from the runtime; allows working with runtime 22.08+
+rm wps-office/office6/libstdc++.so.6
+
 rm -r wps-office.deb deb-package
 
 # Remove plugin path so we can override the default path with based on QT_PLUGIN_PATH

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -52,6 +52,7 @@ modules:
       - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t /app/share/metainfo/
       - install -Dm755 /usr/bin/desktop-file-edit -t /app/bin/
       - install -Dm755 /usr/bin/ar -t /app/bin/
+      - install -Dm755 /usr/lib/x86_64-linux-gnu/libsframe.so* -t /app/lib/
       - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t /app/lib/
       - install -Dm644 com.wps.Office.desktop -t /app/share/applications
       - for icon_size in 64 128 256 512; do install -Dm644 wps_office_${icon_size}.png

--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -41,6 +41,14 @@ modules:
 
   - modules/fcitx-im-module.yml
 
+  # Needed by wpspdf as of 11.1.0.11719
+  - name: libtiff5
+    buildsystem: cmake
+    sources:
+      - type: archive
+        url: https://download.osgeo.org/libtiff/tiff-4.4.0.tar.gz
+        sha256: 917223b37538959aca3b790d2d73aa6e626b688e02dcda272aec24c2f498abed
+
   - name: wps
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Fixes the following issues from the upgrade to 23.08 runtime:
- Includes missing shared libraries used by 23.08 version of `ar` needed during apply_extra phase.
- Removes `libstdc++.so.6` shipped in the .deb to allow falling back to version included in runtime.  The runtime's version is newer and works with other libraries that are built and included in this flatpak.
- Builds libtiff5 for wpspdf.