### PR TITLE
Remove unnecessary filesystem permissions

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -15,11 +15,6 @@ finish-args:
   - --persist=.kingsoft
   - --env=TMPDIR=/var/tmp
   - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-pictures
-  - --filesystem=xdg-videos
-  - --filesystem=/run/media
-  - --filesystem=/media
   - --env=QT_PLUGIN_PATH=/app/lib/qt/plugins:/app/extra/wps-office/office6/qt/plugins
 add-extensions:
   com.wps.Office.spellcheck:


### PR DESCRIPTION
Since WPS Office is an office suite, read-write permission for XDG Documents directory is sufficient for its usage and permission for other directories is unnecessary.