### PR TITLE
Update Freedesktop Platform to 25.08

### DIFF
--- a/com.wps.Office.yml
+++ b/com.wps.Office.yml
@@ -1,6 +1,6 @@
 id: com.wps.Office
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 tags:
   - proprietary
@@ -35,8 +35,6 @@ cleanup:
   - /lib/pkgconfig
   - /lib/cmake
 modules:
-  - shared-modules/gtk2/gtk2.json
-
   - shared-modules/glu/glu-9.json
 
   - modules/fcitx-im-module.yml


### PR DESCRIPTION
The current version of Freedesktop Platform is end of life.

Closes: #165